### PR TITLE
Add the provenance for the npm repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ node:
 
 If the repository server is `npm.pkg.github.com` we will do a login using `GITHUB_TOKEN`.
 
-To publish on `npm.pkg.github.com` you requires the permissions are `packages: write`.
+To publish on `npm.pkg.github.com` you requires the permissions are `packages: write`, and the `id-token: write` for the provenance.
 
 By default the package will be published only on tag.
 

--- a/config.md
+++ b/config.md
@@ -51,6 +51,8 @@ _Tag Publish configuration file_
   - **`repository`** _(object)_: The packages repository where we should publish the packages. Can contain additional properties. Default: `{"github": {"server": "npm.pkg.github.com"}}`.
     - **Additional properties** _(object)_
       - **`server`** _(string)_: The server URL.
+  - **`args`** _(array)_: The arguments to pass to the publish command. Default: `["--provenance"]`.
+    - **Items** _(string)_
 - <a id="definitions/helm"></a>**`helm`** _(object)_: Configuration to publish Helm charts on GitHub release.
   - **`packages`** _(array)_: The configuration of packages that will be published.
     - **Items** _(object)_: The configuration of package that will be published.

--- a/tag_publish/cli.py
+++ b/tag_publish/cli.py
@@ -281,7 +281,12 @@ def _handle_node_publish(
                         )
                     else:
                         success &= tag_publish.publish.node(
-                            package, version, version_type, repo_config, publish
+                            package,
+                            version,
+                            version_type,
+                            repo_config,
+                            publish,
+                            node_config.get("args", tag_publish.configuration.NODE_ARGS_DEFAULT),
                         )
                         if publish:
                             published_payload.append({"type": "node", "folder": folder})

--- a/tag_publish/configuration.py
+++ b/tag_publish/configuration.py
@@ -273,6 +273,10 @@ class HelmPackage(TypedDict, total=False):
     """
 
 
+NODE_ARGS_DEFAULT = ["--provenance"]
+""" Default value of the field path 'node args' """
+
+
 NODE_PACKAGE_FOLDER_DEFAULT = "."
 """ Default value of the field path 'node package folder' """
 
@@ -318,6 +322,16 @@ class Node(TypedDict, total=False):
     default:
       github:
         server: npm.pkg.github.com
+    """
+
+    args: List[str]
+    """
+    Node args.
+
+    The arguments to pass to the publish command
+
+    default:
+      - --provenance
     """
 
 

--- a/tag_publish/publish.py
+++ b/tag_publish/publish.py
@@ -110,6 +110,7 @@ def node(
     version_type: str,
     repo_config: tag_publish.configuration.NodeRepository,
     publish: bool,
+    args: list[str],
 ) -> bool:
     """
     Publish node package to npm.
@@ -122,6 +123,7 @@ def node(
         publish: If False only check the package
         package: The package configuration
         github: The GitHub helper
+        args: The additional arguments to pass to npm publish
 
     """
     folder = package.get("folder", tag_publish.configuration.PYPI_PACKAGE_FOLDER_DEFAULT)
@@ -152,7 +154,7 @@ def node(
                 open_file.write(f"registry=https://{repo_config['server']}\n")
                 open_file.write("always-auth=true\n")
 
-        subprocess.run(["npm", "publish", *([] if publish else ["--dry-run"])], cwd=cwd, check=True)
+        subprocess.run(["npm", "publish", *([] if publish else ["--dry-run"]), *args], cwd=cwd, check=True)
 
         if is_github:
             if old_npmrc is None:

--- a/tag_publish/schema.json
+++ b/tag_publish/schema.json
@@ -186,6 +186,15 @@
               }
             }
           }
+        },
+        "args": {
+          "title": "Node args",
+          "description": "The arguments to pass to the publish command",
+          "type": "array",
+          "default": ["--provenance"],
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
See also:
- https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
- https://docs.npmjs.com/generating-provenance-statements