### PR TITLE
Publish Helm charts to OCI registry with cosign signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Set the permissions:
 
 ```yaml
 permissions:
-  # To publish Docker images on GHCR and on npm.pkg.github.com
+  # To publish Docker images on GHCR, npm packages and Helm charts on OCI registry
   packages: write
-  # To publish Python packages using OIDC
+  # To publish Python packages using OIDC and for cosign keyless signing
   id-token: write
-  # To publish Helm charts and send repository dispatch notifications
+  # To publish Helm charts (chart-releaser) and send repository dispatch notifications
   contents: write
 ```
 
@@ -278,6 +278,36 @@ git checkout --orphan gh-pages
 git reset --hard
 git commit --allow-empty -m "Initialize gh-pages branch"
 git push origin gh-pages
+```
+
+#### OCI registry publishing
+
+By default, the Helm chart is also published to an OCI registry (`ghcr.io/<owner>/<repo>`) and signed with [cosign](https://github.com/sigstore/cosign) using keyless signing.
+
+The chart is pushed to `ghcr.io/<owner>/<repo>:<version>` automatically.
+
+The required permissions are `packages: write` (for pushing to ghcr.io) and `id-token: write` (for cosign keyless signing).
+
+To customize the OCI publishing:
+
+```yaml
+helm:
+  packages:
+    - folder: charts/my-chart
+  oci:
+    enabled: true # default: true
+    registry: ghcr.io # default: ghcr.io
+    sign: true # default: true, keyless signing via cosign
+```
+
+To disable OCI publishing:
+
+```yaml
+helm:
+  packages:
+    - {}
+  oci:
+    enabled: false
 ```
 
 ## Dispatch

--- a/config.md
+++ b/config.md
@@ -54,13 +54,17 @@ _Tag Publish configuration file (.github/publish.yaml)_
       - <a id="definitions/node/properties/repository/additionalProperties/properties/host"></a>**`host`** _(string)_: The host of the repository URL.
   - <a id="definitions/node/properties/args"></a>**`args`** _(array)_: The arguments to pass to the publish command. Default: `["--provenance", "--access=public"]`.
     - <a id="definitions/node/properties/args/items"></a>**Items** _(string)_
-- <a id="definitions/helm"></a>**`helm`** _(object)_: Configuration to publish Helm charts on GitHub release. Cannot contain additional properties.
+- <a id="definitions/helm"></a>**`helm`** _(object)_: Configuration to publish Helm charts on GitHub release and OCI registry. Cannot contain additional properties.
   - <a id="definitions/helm/properties/packages"></a>**`packages`** _(array)_: The configuration of packages that will be published.
     - <a id="definitions/helm/properties/packages/items"></a>**Items** _(object)_: The configuration of package that will be published. Cannot contain additional properties.
       - <a id="definitions/helm/properties/packages/items/properties/group"></a>**`group`** _(string)_: The image is in the group, should be used with the --group option of tag-publish script. Default: `"default"`.
       - <a id="definitions/helm/properties/packages/items/properties/folder"></a>**`folder`** _(string)_: The folder of the pypi package. Default: `"."`.
   - <a id="definitions/helm/properties/versions_type"></a>**`versions_type`** _(array)_: The kind or version that should be published, tag, branch or value of the --version argument of the tag-publish script. Default: `["tag"]`.
     - <a id="definitions/helm/properties/versions_type/items"></a>**Items** _(string)_
+  - <a id="definitions/helm/properties/oci"></a>**`oci`** _(object)_: The configuration for Helm chart publishing on OCI registry. Cannot contain additional properties.
+    - <a id="definitions/helm/properties/oci/properties/enabled"></a>**`enabled`** _(boolean)_: Enable publishing to an OCI registry. Default: `true`.
+    - <a id="definitions/helm/properties/oci/properties/registry"></a>**`registry`** _(string)_: The OCI registry host. Default: `"ghcr.io"`.
+    - <a id="definitions/helm/properties/oci/properties/sign"></a>**`sign`** _(boolean)_: Enable keyless signing of the chart using cosign. Default: `true`.
 - <a id="definitions/transform"></a>**`transform`** _(array)_: A version transformer definition. Default: `[]`.
   - <a id="definitions/transform/items"></a>**Items** _(object)_: Cannot contain additional properties.
     - <a id="definitions/transform/items/properties/from_re"></a>**`from_re`** _(string)_: The from regular expression. Default: `"(.+)"`.

--- a/tag_publish/cli.py
+++ b/tag_publish/cli.py
@@ -470,7 +470,16 @@ def _handle_helm_publish(
                         print(f"Publishing '{folder}' to helm, skipping (dry run)")
                     else:
                         token = os.environ["GITHUB_TOKEN"]
-                        success &= tag_publish.publish.helm(folder, version, owner, repo, commit_sha, token)
+                        oci_config = helm_config.get("oci")
+                        success &= tag_publish.publish.helm(
+                            folder,
+                            version,
+                            owner,
+                            repo,
+                            commit_sha,
+                            token,
+                            oci_config,
+                        )
                         published_payload.append({"type": "helm", "folder": folder})
                 else:
                     print(

--- a/tag_publish/configuration.py
+++ b/tag_publish/configuration.py
@@ -49,7 +49,7 @@ class Configuration(TypedDict, total=False):
     r"""
     helm.
 
-    Configuration to publish Helm charts on GitHub release
+    Configuration to publish Helm charts on GitHub release and OCI registry
     """
 
     dispatch: list["DispatchConfig"]
@@ -238,6 +238,21 @@ class DockerRepository(TypedDict, total=False):
 
 
 
+HELM_OCI_ENABLED_DEFAULT = True
+r""" Default value of the field path 'helm OCI enabled' """
+
+
+
+HELM_OCI_REGISTRY_DEFAULT = 'ghcr.io'
+r""" Default value of the field path 'helm OCI registry' """
+
+
+
+HELM_OCI_SIGN_DEFAULT = True
+r""" Default value of the field path 'helm OCI sign' """
+
+
+
 HELM_PACKAGE_FOLDER_DEFAULT = '.'
 r""" Default value of the field path 'helm package folder' """
 
@@ -257,7 +272,7 @@ class Helm(TypedDict, total=False):
     r"""
     helm.
 
-    Configuration to publish Helm charts on GitHub release
+    Configuration to publish Helm charts on GitHub release and OCI registry
     """
 
     packages: list["HelmPackage"]
@@ -271,6 +286,49 @@ class Helm(TypedDict, total=False):
 
     default:
       - tag
+    """
+
+    oci: "HelmOci"
+    r"""
+    helm OCI.
+
+    The configuration for Helm chart publishing on OCI registry
+    """
+
+
+
+class HelmOci(TypedDict, total=False):
+    r"""
+    helm OCI.
+
+    The configuration for Helm chart publishing on OCI registry
+    """
+
+    enabled: bool
+    r"""
+    helm OCI enabled.
+
+    Enable publishing to an OCI registry
+
+    default: True
+    """
+
+    registry: str
+    r"""
+    helm OCI registry.
+
+    The OCI registry host
+
+    default: ghcr.io
+    """
+
+    sign: bool
+    r"""
+    helm OCI sign.
+
+    Enable keyless signing of the chart using cosign
+
+    default: True
     """
 
 

--- a/tag_publish/publish.py
+++ b/tag_publish/publish.py
@@ -7,7 +7,6 @@ import re
 import subprocess  # nosec
 import sys
 from pathlib import Path
-from typing import Any
 
 import ruamel
 import tomllib

--- a/tag_publish/publish.py
+++ b/tag_publish/publish.py
@@ -7,10 +7,12 @@ import re
 import subprocess  # nosec
 import sys
 from pathlib import Path
+from typing import Any
 
 import ruamel
 import tomllib
 
+import tag_publish
 import tag_publish.configuration
 
 
@@ -263,7 +265,15 @@ def docker(
     return True
 
 
-def helm(folder: str, version: str, owner: str, repo: str, commit_sha: str, token: str) -> bool:
+def helm(
+    folder: str,
+    version: str,
+    owner: str,
+    repo: str,
+    commit_sha: str,
+    token: str,
+    oci_config: tag_publish.configuration.HelmOci | None = None,
+) -> bool:
     """
     Publish to pypi.
 
@@ -274,17 +284,20 @@ def helm(folder: str, version: str, owner: str, repo: str, commit_sha: str, toke
         repo: The GitHub repository name
         commit_sha: The sha of the current commit
         token: The GitHub token
+        oci_config: The OCI registry configuration
 
     """
     print(f"::group::Publishing Helm chart from '{folder}' to GitHub release")
     sys.stdout.flush()
     sys.stderr.flush()
 
+    chart_name = ""
     try:
         yaml_ = ruamel.yaml.YAML()
         with (Path(folder) / "Chart.yaml").open(encoding="utf-8") as open_file:
             chart = yaml_.load(open_file)
         chart["version"] = version
+        chart_name = chart.get("name", "")
         with (Path(folder) / "Chart.yaml").open("w", encoding="utf-8") as open_file:
             yaml_.dump(chart, open_file)
         for index, dependency in enumerate(chart.get("dependencies", [])):
@@ -327,6 +340,39 @@ def helm(folder: str, version: str, owner: str, repo: str, commit_sha: str, toke
             check=True,
         )
         print("::endgroup::")
+
+        oci_config = oci_config or {}
+        if oci_config.get("enabled", tag_publish.configuration.HELM_OCI_ENABLED_DEFAULT):
+            registry = oci_config.get("registry", tag_publish.configuration.HELM_OCI_REGISTRY_DEFAULT)
+            oci_repository = f"{registry}/{owner}/{repo}"
+            print(f"::group::Publishing Helm chart '{folder}' to OCI registry {oci_repository}")
+
+            subprocess.run(
+                ["helm", "registry", "login", registry, f"--username={owner}", f"--password={token}"],
+                check=True,
+            )
+
+            chart_archive = f"{chart_name}-{version}.tgz"
+            if not Path(chart_archive).exists():
+                print(f"Error: chart archive {chart_archive} not found")
+                print("::endgroup::")
+                print("::error::Chart archive not found")
+                return False
+            subprocess.run(
+                ["helm", "push", chart_archive, f"oci://{oci_repository}"],
+                check=True,
+            )
+
+            if oci_config.get("sign", tag_publish.configuration.HELM_OCI_SIGN_DEFAULT):
+                print(f"Signing chart with cosign at oci://{oci_repository}:{version}")
+                tag_publish.download_application("sigstore/cosign")
+                subprocess.run(
+                    ["cosign", "sign", f"oci://{oci_repository}:{version}", "--yes"],
+                    check=True,
+                )
+
+            print("::endgroup::")
+
     except subprocess.CalledProcessError as exception:
         print(f"Error: {exception}")
         print("::endgroup::")

--- a/tag_publish/schema.json
+++ b/tag_publish/schema.json
@@ -215,7 +215,7 @@
     },
     "helm": {
       "title": "helm",
-      "description": "Configuration to publish Helm charts on GitHub release",
+      "description": "Configuration to publish Helm charts on GitHub release and OCI registry",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -250,6 +250,32 @@
           "default": ["tag"],
           "items": {
             "type": "string"
+          }
+        },
+        "oci": {
+          "title": "helm OCI",
+          "description": "The configuration for Helm chart publishing on OCI registry",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "description": "Enable publishing to an OCI registry",
+              "title": "helm OCI enabled",
+              "default": true,
+              "type": "boolean"
+            },
+            "registry": {
+              "description": "The OCI registry host",
+              "title": "helm OCI registry",
+              "default": "ghcr.io",
+              "type": "string"
+            },
+            "sign": {
+              "description": "Enable keyless signing of the chart using cosign",
+              "title": "helm OCI sign",
+              "default": true,
+              "type": "boolean"
+            }
           }
         }
       }

--- a/tag_publish/versions.yaml
+++ b/tag_publish/versions.yaml
@@ -1,2 +1,3 @@
 # https://docs.renovatebot.com/modules/datasource/#github-releases-datasource
 helm/chart-releaser: v1.8.1 # github-releases
+sigstore/cosign: v3.1.1 # github-releases


### PR DESCRIPTION
Implements https://github.com/camptocamp/helm-geoserver-cloud/issues/351

## Changes

By default, when a Helm package is configured, `tag-publish` will now also:
1. **Push the chart to an OCI registry** (`ghcr.io/<owner>/<repo>:<version>`) using `helm push`
2. **Sign the chart** with cosign keyless signing via GitHub Actions OIDC

No configuration changes are required — OCI publishing is enabled by default. Users can opt out via:

```yaml
helm:
  packages:
    - {}
  oci:
    enabled: false
```

### Files modified

- `tag_publish/versions.yaml` — Added `sigstore/cosign: v3.1.1`
- `tag_publish/schema.json` — Added `helm.oci` config section (enabled, registry, sign)
- `tag_publish/configuration.py` — Added `HelmOCI` TypedDict and defaults
- `tag_publish/publish.py` — Added `helm registry login`, `helm push`, and `cosign sign` steps
- `tag_publish/cli.py` — Pass OCI config to publish function
- `README.md` — Documented OCI publishing and updated permission descriptions

<!-- pull request links -->
See JIRA issue: [GSOO-351](https://camptocamp.atlassian.net/browse/GSOO-351).