### PR TITLE
Fix Helm OCI chart archive path for cr package output directory

### DIFF
--- a/tag_publish/publish.py
+++ b/tag_publish/publish.py
@@ -351,7 +351,7 @@ def helm(
                 check=True,
             )
 
-            chart_archive = f"{chart_name}-{version}.tgz"
+            chart_archive = f".cr-release-packages/{chart_name}-{version}.tgz"
             if not Path(chart_archive).exists():
                 print(f"Error: chart archive {chart_archive} not found")
                 print("::endgroup::")


### PR DESCRIPTION
The  command outputs chart archives to `.cr-release-packages/` by default (chart-releaser v1.8.1), but the OCI publishing code was looking for the archive in the current working directory.

Fix: prepend `.cr-release-packages/` to the chart archive path when pushing to OCI registry.

<!-- pull request links -->
See JIRA issue: [GSOO-351](https://camptocamp.atlassian.net/browse/GSOO-351).