### PR TITLE
Use PEP 621 project.dependencies with exact pins for Renovate detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     'Programming Language :: Python :: 3.13',
     'Typing :: Typed',
 ]
-dynamic = ["dependencies", "version"]
+dynamic = ["version"]
 name = "tag-publish"
 description = "Tools used to publish Python packages, Docker images and Helm charts for GitHub tag and branch"
 readme = "README.md"


### PR DESCRIPTION
Remove `dynamic = ["dependencies"]` from `[project]` and move exact version pins from `[tool.poetry.dependencies]` to `[project].dependencies` (PEP 621 format) so Renovate can detect and manage them.

<!-- pull request links -->
See JIRA issue: [DEPS-2](https://camptocamp.atlassian.net/browse/DEPS-2).