### PR TITLE
Pin ruff and pylint in the project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,6 +132,7 @@ repos:
           - prospector-profile-utils==1.27.0 # pypi
           - mypy==2.3.0 # pypi
           - ruff==0.15.21 # pypi
+          - pylint[spelling]==4.0.6 # pypi
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.21
     hooks:


### PR DESCRIPTION
Prospector uses ruff and pylint, they should be pinned alongside prospector.