### PR TITLE
Replace --die-on-tool-error by --direct-tool-stdout in prospector

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - run: poetry install
       - name: Prospector
-        run: poetry run prospector --die-on-tool-error --output-format=pylint
+        run: poetry run prospector --direct-tool-stdout --output-format=pylint
 
       - run: docker build --tag camptocamp/tag-publish tests
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
       - id: prospector
         args:
           - --profile=utils:pre-commit
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=.prospector.yaml
         additional_dependencies:
@@ -124,7 +124,7 @@ repos:
           )
       - id: prospector
         args:
-          - --die-on-tool-error
+          - --direct-tool-stdout
           - --output-format=pylint
           - --profile=utils:tests
           - --profile=utils:pre-commit


### PR DESCRIPTION
Prospector --die-on-tool-error is replaced by --direct-tool-stdout.